### PR TITLE
APM-255 Переход на npoed-massmail

### DIFF
--- a/extension_email/notifications.py
+++ b/extension_email/notifications.py
@@ -4,7 +4,7 @@ import base64
 from django.core.urlresolvers import reverse
 from django.template import Template, Context
 from django.utils.translation import ugettext_lazy as _
-from plp.notifications.base import MassSendEmails
+from npoed_massmail.base import MassSendEmails
 
 
 class BulkEmailSend(MassSendEmails):

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='npoed-plp-extension-email',
-    version='0.1',
+    version='0.1.1',
     packages=find_packages(),
     description='PLP extension email',
     url='http://example.com',
     author='author',
+    dependency_links=['https://github.com/npoed/npoed-massmail/tarball/master#egg=npoed_massmail-0.1'],
+    install_requires=["npoed_massmail==0.1"],
 )
 


### PR DESCRIPTION
Поскольку код из plp.notifications.base перемещён в `npoed-massmail` (см. APM-255), в данном расширении тоже нужны изменения.

Поменял импорт и добавил `npoed-massmail` в зависимости.

Ставить `npoed-plp-extension-email` теперь нужно так:
```
pip install -e git+https://github.com/martynovp/npoed-plp-extension-email@master#egg=extension_email --process-dependency-links --allow-all-external
```

PIP ругается на то, что опция `--process-dependency-links` deprecated, но другого способа добавить зависимость с гитхаба пока нет.

`requirements.txt` в PLP изменены [тут](https://github.com/npoed/npoed-plp-edx/commit/18ecbf930aab87234f9b78ee03a956cb31e8d41b)